### PR TITLE
Add support for `0` (or `newline`) option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var plural = require('plur')
 
 module.exports = sentenceSpacing
 
+var id = 'retext-sentence-spacing:retext-sentence-spacing'
+
 function sentenceSpacing(options) {
   var preferred = (options || {}).preferred
 
@@ -14,14 +16,16 @@ function sentenceSpacing(options) {
     preferred = 1
   }
 
-  if (typeof preferred !== 'number') {
-    throw new Error(
-      "Expected `options.preferred` to be `'space'` or a `number`"
-    )
-  }
+  if (preferred !== 'newline') {
+    if (typeof preferred !== 'number') {
+      throw new Error(
+        "Expected `options.preferred` to be `'space'`, `'newline'`, or a `number`"
+      )
+    }
 
-  if (preferred < 1 || preferred > 2) {
-    throw new Error('Expected `options.preferred` to be `1` or `2`')
+    if (preferred !== 1 && preferred !== 2) {
+      throw new Error('Expected `options.preferred` to be `1` or `2`')
+    }
   }
 
   return transformer
@@ -36,41 +40,51 @@ function sentenceSpacing(options) {
       var value
       var child
       var size
-      var message
 
       while (++index < length) {
         child = children[index]
 
         if (
-          is('SentenceNode', children[index - 1]) &&
-          is('WhiteSpaceNode', child) &&
-          is('SentenceNode', children[index + 1])
+          !is('SentenceNode', children[index - 1]) ||
+          !is('WhiteSpaceNode', child) ||
+          !is('SentenceNode', children[index + 1])
         ) {
-          value = toString(child)
+          continue
+        }
 
-          /* Ignore anything with non-spaces. */
-          if (!/^ +$/.test(value)) {
-            continue
-          }
+        value = toString(child)
 
-          size = value.length
+        /* We only check for white-space that is *just* spaces: it’s OK to add
+         * newlines if `space` is expected. */
+        if (!/^ +$/.test(value)) {
+          continue
+        }
 
-          if (size !== preferred) {
-            message = file.warn(
-              'Expected `' +
-                preferred +
-                '` ' +
-                plural('space', preferred) +
-                ' between ' +
-                'sentences, not `' +
-                size +
-                '`',
-              child
-            )
+        size = value.length
 
-            message.source = 'retext-sentence-spacing'
-            message.ruleId = 'retext-sentence-spacing'
-          }
+        /* Size is never preferred if we want a newline. */
+        if (preferred === 'newline') {
+          file.warn(
+            'Expected a newline between sentences, not `' +
+              size +
+              '` ' +
+              plural('space', size),
+            child,
+            id
+          )
+        } else if (size !== preferred) {
+          file.warn(
+            'Expected `' +
+              preferred +
+              '` ' +
+              plural('space', preferred) +
+              ' between ' +
+              'sentences, not `' +
+              size +
+              '`',
+            child,
+            id
+          )
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,16 @@ function sentenceSpacing(options) {
     preferred = 1
   }
 
+  if (typeof preferred !== 'number') {
+    throw new Error(
+      "Expected `options.preferred` to be `'space'` or a `number`"
+    )
+  }
+
+  if (preferred < 1 || preferred > 2) {
+    throw new Error('Expected `options.preferred` to be `1` or `2`')
+  }
+
   return transformer
 
   function transformer(tree, file) {

--- a/index.js
+++ b/index.js
@@ -16,16 +16,20 @@ function sentenceSpacing(options) {
     preferred = 1
   }
 
-  if (preferred !== 'newline') {
-    if (typeof preferred !== 'number') {
-      throw new Error(
-        "Expected `options.preferred` to be `'space'`, `'newline'`, or a `number`"
-      )
-    }
+  if (preferred === 'newline') {
+    preferred = 0
+  }
 
-    if (preferred !== 1 && preferred !== 2) {
-      throw new Error('Expected `options.preferred` to be `1` or `2`')
-    }
+  if (typeof preferred !== 'number') {
+    throw new Error(
+      "Expected `options.preferred` to be `'space'`, `'newline'`, or a `number`"
+    )
+  }
+
+  if (preferred < 0 || preferred > 2) {
+    throw new Error(
+      "Expected `options.preferred` to be `'space'`, `'newline'`, or a `number` between (including) `0` and `2`"
+    )
   }
 
   return transformer
@@ -63,7 +67,7 @@ function sentenceSpacing(options) {
         size = value.length
 
         /* Size is never preferred if we want a newline. */
-        if (preferred === 'newline') {
+        if (preferred === 0) {
           file.warn(
             'Expected a newline between sentences, not `' +
               size +

--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ var plural = require('plur')
 module.exports = sentenceSpacing
 
 function sentenceSpacing(options) {
-  var preferred = (options || {}).preferred || 1
+  var preferred = (options || {}).preferred
+
+  if (preferred === null || preferred === undefined || preferred === 'space') {
+    preferred = 1
+  }
 
   return transformer
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
   "xo": {
     "prettier": true,
     "esnext": false,
+    "rules": {
+      "unicorn/prefer-type-error": "off"
+    },
     "ignores": [
       "retext-sentence-spacing.js"
     ]

--- a/readme.md
+++ b/readme.md
@@ -72,8 +72,8 @@ to the preferred style.
 
 ###### `options.preferred`
 
-*   `'newline'` — Disallow spaces between sentences
-*   `'space'` (or `1`, default) — Allow only one space between sentences
+*   `0` (or `'newline'`) — Disallow spaces between sentences
+*   `1` (or `'space'`, default) — Allow only one space between sentences
 *   `2` — Allow only two space between sentences
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,9 @@ to the preferred style.
 
 ###### `options.preferred`
 
-`1` or `2`, default: `1` — Number of expected spaces.
+*   `'newline'` — Disallow spaces between sentences
+*   `'space'` (or `1`, default) — Allow only one space between sentences
+*   `2` — Allow only two space between sentences
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -13,7 +13,9 @@ var mixed = [
 ].join('\n')
 
 test('sentenceSpacing(value[, size])', function(t) {
+  var zero = [0, 'newline']
   var one = [null, 'space', 1]
+  var two = [2]
 
   one.forEach(function(pref) {
     t.deepEqual(
@@ -26,26 +28,30 @@ test('sentenceSpacing(value[, size])', function(t) {
     )
   })
 
-  t.deepEqual(
-    retext()
-      .use(spacing, {preferred: 2})
-      .processSync(mixed)
-      .messages.map(String),
-    ['1:14-1:15: Expected `2` spaces between sentences, not `1`'],
-    'should catch single spaces when preferred == 2'
-  )
+  two.forEach(function(pref) {
+    t.deepEqual(
+      retext()
+        .use(spacing, {preferred: pref})
+        .processSync(mixed)
+        .messages.map(String),
+      ['1:14-1:15: Expected `2` spaces between sentences, not `1`'],
+      'should catch single spaces when preferred == ' + pref
+    )
+  })
 
-  t.deepEqual(
-    retext()
-      .use(spacing, {preferred: 'newline'})
-      .processSync(mixed)
-      .messages.map(String),
-    [
-      '1:14-1:15: Expected a newline between sentences, not `1` space',
-      '3:14-3:16: Expected a newline between sentences, not `2` spaces'
-    ],
-    'should catch single spaces when preferred == 2'
-  )
+  zero.forEach(function(pref) {
+    t.deepEqual(
+      retext()
+        .use(spacing, {preferred: pref})
+        .processSync(mixed)
+        .messages.map(String),
+      [
+        '1:14-1:15: Expected a newline between sentences, not `1` space',
+        '3:14-3:16: Expected a newline between sentences, not `2` spaces'
+      ],
+      'should catch single spaces when preferred == ' + pref
+    )
+  })
 
   t.deepEqual(
     retext()
@@ -68,10 +74,10 @@ test('sentenceSpacing(value[, size])', function(t) {
   t.throws(
     function() {
       retext()
-        .use(spacing, {preferred: 0})
+        .use(spacing, {preferred: -1})
         .freeze()
     },
-    /Error: Expected `options.preferred` to be `1` or `2`/,
+    /Error: Expected `options.preferred` to be `'space'`, `'newline'`, or a `number` between \(including\) `0` and `2`/,
     'should throw for preferred lower than 1'
   )
 
@@ -81,7 +87,7 @@ test('sentenceSpacing(value[, size])', function(t) {
         .use(spacing, {preferred: 3})
         .freeze()
     },
-    /Error: Expected `options.preferred` to be `1` or `2`/,
+    /Error: Expected `options.preferred` to be `'space'`, `'newline'`, or a `number` between \(including\) `0` and `2`/,
     'should throw for preferred higher than 2'
   )
 

--- a/test.js
+++ b/test.js
@@ -59,5 +59,35 @@ test('retext-sentence-spacing(value[, size])', function(t) {
     'should not emit messages for non-space white-space'
   )
 
+  t.throws(
+    function() {
+      retext()
+        .use(spacing, {preferred: 0})
+        .freeze()
+    },
+    /Error: Expected `options.preferred` to be `1` or `2`/,
+    'should throw for preferred lower than 1'
+  )
+
+  t.throws(
+    function() {
+      retext()
+        .use(spacing, {preferred: 3})
+        .freeze()
+    },
+    /Error: Expected `options.preferred` to be `1` or `2`/,
+    'should throw for preferred higher than 2'
+  )
+
+  t.throws(
+    function() {
+      retext()
+        .use(spacing, {preferred: 'foo'})
+        .freeze()
+    },
+    /Error: Expected `options.preferred` to be `'space'` or a `number`/,
+    'should throw for non-numbers'
+  )
+
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -10,52 +10,44 @@ var mixed = [
   'One sentence.  Two sentences.'
 ].join('\n')
 
-var many = 'One sentence.   Three sentences.'
-
-var nonSpace = 'One sentence.\tFour sentences.'
-
-test('retext-sentence-spacing(value[, size])', function(t) {
+test('sentenceSpacing(value[, size])', function(t) {
   var one = [null, 'space', 1]
 
   one.forEach(function(pref) {
-    t.equal(
-      String(
-        retext()
-          .use(spacing, {preferred: pref})
-          .processSync(mixed).messages
-      ),
-      '3:14-3:16: Expected `1` space between sentences, not `2`',
+    t.deepEqual(
+      retext()
+        .use(spacing, {preferred: pref})
+        .processSync(mixed)
+        .messages.map(String),
+      ['3:14-3:16: Expected `1` space between sentences, not `2`'],
       'should catch double spaces when preferred == ' + pref
     )
   })
 
-  t.equal(
-    String(
-      retext()
-        .use(spacing, {preferred: 2})
-        .processSync(mixed).messages
-    ),
-    '1:14-1:15: Expected `2` spaces between sentences, not `1`',
+  t.deepEqual(
+    retext()
+      .use(spacing, {preferred: 2})
+      .processSync(mixed)
+      .messages.map(String),
+    ['1:14-1:15: Expected `2` spaces between sentences, not `1`'],
     'should catch single spaces when preferred == 2'
   )
 
-  t.equal(
-    String(
-      retext()
-        .use(spacing)
-        .processSync(many).messages
-    ),
-    '1:14-1:17: Expected `1` space between sentences, not `3`',
+  t.deepEqual(
+    retext()
+      .use(spacing)
+      .processSync('One sentence.   Three sentences.')
+      .messages.map(String),
+    ['1:14-1:17: Expected `1` space between sentences, not `3`'],
     'should catch more than two spaces'
   )
 
-  t.equal(
-    String(
-      retext()
-        .use(spacing)
-        .processSync(nonSpace).messages
-    ),
-    '',
+  t.deepEqual(
+    retext()
+      .use(spacing)
+      .processSync('One sentence.\tFour sentences.')
+      .messages.map(String),
+    [],
     'should not emit messages for non-space white-space'
   )
 

--- a/test.js
+++ b/test.js
@@ -7,7 +7,9 @@ var spacing = require('.')
 var mixed = [
   'One sentence. Two sentences.',
   '',
-  'One sentence.  Two sentences.'
+  'One sentence.  Two sentences.',
+  '',
+  'One sentence.\nTwo sentences.'
 ].join('\n')
 
 test('sentenceSpacing(value[, size])', function(t) {
@@ -30,6 +32,18 @@ test('sentenceSpacing(value[, size])', function(t) {
       .processSync(mixed)
       .messages.map(String),
     ['1:14-1:15: Expected `2` spaces between sentences, not `1`'],
+    'should catch single spaces when preferred == 2'
+  )
+
+  t.deepEqual(
+    retext()
+      .use(spacing, {preferred: 'newline'})
+      .processSync(mixed)
+      .messages.map(String),
+    [
+      '1:14-1:15: Expected a newline between sentences, not `1` space',
+      '3:14-3:16: Expected a newline between sentences, not `2` spaces'
+    ],
     'should catch single spaces when preferred == 2'
   )
 
@@ -77,7 +91,7 @@ test('sentenceSpacing(value[, size])', function(t) {
         .use(spacing, {preferred: 'foo'})
         .freeze()
     },
-    /Error: Expected `options.preferred` to be `'space'` or a `number`/,
+    /Error: Expected `options.preferred` to be `'space'`, `'newline'`, or a `number`/,
     'should throw for non-numbers'
   )
 

--- a/test.js
+++ b/test.js
@@ -15,7 +15,9 @@ var many = 'One sentence.   Three sentences.'
 var nonSpace = 'One sentence.\tFour sentences.'
 
 test('retext-sentence-spacing(value[, size])', function(t) {
-  ;[null, 1].forEach(function(pref) {
+  var one = [null, 'space', 1]
+
+  one.forEach(function(pref) {
     t.equal(
       String(
         retext()


### PR DESCRIPTION
Previously, spaces between sentences where checked, and warned about if they did not match the given preferred size. Now, some people like newlines between sentences. Which makes sense. But the previous code did not allow for that. This code, based on GH-5 and GH-6, adds support for checking that spaces are *not* used between sentences.

Additionally, errors are thrown for out-of-range values (lower than 0 or higher than 2), and non-number values.

Note however that this plugin only checks white-space consisting of just spaces between sentences. It doesn’t check other delimiters (such as tabs, newlines, or mixed white-space).

Closes GH-5.
Closes GH-6.

Co-authored-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de>